### PR TITLE
Enhance Help

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -4,7 +4,7 @@
   pageNav: 3
 ---
 
-# AB-3 User Guide
+# Homey User Guide
 
 AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized for use via a  Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3 can get your contact management tasks done faster than traditional GUI apps.
 

--- a/src/main/java/homey/commons/util/BrowserUtil.java
+++ b/src/main/java/homey/commons/util/BrowserUtil.java
@@ -1,0 +1,34 @@
+package homey.commons.util;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Utility class to open a URL in the system's default web browser.
+ */
+public final class BrowserUtil {
+    private BrowserUtil() {}
+
+    /**
+     * Tries to open the given URL in the system's default browser.
+     *
+     * @param url The URL to open.
+     * @return true if the browser was opened successfully, false otherwise.
+     */
+    public static boolean open(String url) {
+        try {
+            if (!Desktop.isDesktopSupported()) {
+                return false;
+            }
+            Desktop desktop = Desktop.getDesktop();
+            if (!desktop.isSupported(Desktop.Action.BROWSE)) {
+                return false;
+            }
+            desktop.browse(URI.create(url));
+            return true;
+        } catch (IOException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/homey/logic/commands/CommandResult.java
+++ b/src/main/java/homey/logic/commands/CommandResult.java
@@ -3,6 +3,7 @@ package homey.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import homey.commons.util.ToStringBuilder;
 
@@ -19,13 +20,14 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** Optional help topic (e.g., "add", "edit") to open a specific UG anchor. */
+    private final Optional<String> helpTopic;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
+        this(feedbackToUser, showHelp, exit, Optional.empty());
     }
 
     /**
@@ -33,7 +35,17 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, Optional.empty());
+    }
+
+    /**
+     * New canonical constructor that allows passing an optional help topic.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, Optional<String> helpTopic) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = showHelp;
+        this.exit = exit;
+        this.helpTopic = helpTopic == null ? Optional.empty() : helpTopic;
     }
 
     public String getFeedbackToUser() {
@@ -48,35 +60,42 @@ public class CommandResult {
         return exit;
     }
 
+    /**
+     * Returns the optional help topic (e.g. "add") if present.
+     *
+     * @return the help topic, or an empty Optional if none was provided.
+     */
+    public Optional<String> getHelpTopic() {
+        return helpTopic;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
         }
-
-        // instanceof handles nulls
         if (!(other instanceof CommandResult)) {
             return false;
         }
-
-        CommandResult otherCommandResult = (CommandResult) other;
-        return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+        CommandResult o = (CommandResult) other;
+        return feedbackToUser.equals(o.feedbackToUser)
+                && showHelp == o.showHelp
+                && exit == o.exit
+                && helpTopic.equals(o.helpTopic);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, helpTopic);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
+        ToStringBuilder builder = new ToStringBuilder(this)
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
-                .add("exit", exit)
-                .toString();
+                .add("exit", exit);
+        helpTopic.ifPresent(topic -> builder.add("helpTopic", topic));
+        return builder.toString();
     }
-
 }

--- a/src/main/java/homey/logic/commands/HelpCommand.java
+++ b/src/main/java/homey/logic/commands/HelpCommand.java
@@ -1,21 +1,75 @@
 package homey.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Locale;
+import java.util.Optional;
+
 import homey.model.Model;
 
 /**
- * Format full help instructions for every command for display.
+ * Opens the User Guide. Optionally accepts a topic to open the guide at a specific section.
+ * Usage: {@code help [topic]} e.g., {@code help add}
  */
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Opens the User Guide.\n"
+            + "Usage: " + COMMAND_WORD + " [topic]\n"
+            + "Examples: " + COMMAND_WORD + ", " + COMMAND_WORD + " add, " + COMMAND_WORD + " edit";
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String SHOWING_HELP_MESSAGE = "Opened help.";
 
+    /** Optional topic such as "add", "edit", etc. */
+    private final Optional<String> topic;
+
+    /** Creates a HelpCommand with no topic (same as 'help'). */
+    public HelpCommand() {
+        this.topic = Optional.empty();
+    }
+
+    /**
+     * Creates a HelpCommand with a topic (e.g. "add").
+     * The topic is lowercased and trimmed, empty input is ignored.
+     */
+    public HelpCommand(String topic) {
+        this.topic = Optional.ofNullable(topic)
+                .map(s -> s.toLowerCase(Locale.ROOT).trim())
+                .filter(s -> !s.isEmpty());
+    }
+
+    /** Returns the optional topic, if provided. */
+    public Optional<String> getTopic() {
+        return topic;
+    }
+
+    /**
+     * Returns a CommandResult that signals the UI to show help,
+     * optionally with a topic anchor. */
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        requireNonNull(model);
+        // Uses new CommandResult ctor that carries an optional helpTopic.
+        return new CommandResult(SHOWING_HELP_MESSAGE, /*showHelp=*/true, /*exit=*/false, /*helpTopic=*/topic);
+    }
+
+    /** Two HelpCommands are equal if their topics are equal. */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof HelpCommand)) {
+            return false;
+        }
+        HelpCommand otherHelpCommand = (HelpCommand) other;
+        return topic.equals(otherHelpCommand.topic);
+    }
+
+    /** Hash code based on the optional topic. */
+    @Override
+    public int hashCode() {
+        return topic.hashCode();
     }
 }

--- a/src/main/java/homey/logic/parser/AddressBookParser.java
+++ b/src/main/java/homey/logic/parser/AddressBookParser.java
@@ -31,6 +31,23 @@ public class AddressBookParser {
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
     /**
+     * Parses the help command with an optional topic.
+     * Examples:
+     *  - "help" -> new HelpCommand()
+     *  - "help add" -> new HelpCommand("add")
+     *
+     * @param arguments The raw arguments after the "help" keyword.
+     * @return a HelpCommand with or without a topic.
+     */
+    private Command parseHelp(String arguments) {
+        String trimmed = arguments.trim();
+        if (trimmed.isEmpty()) {
+            return new HelpCommand();
+        }
+        return new HelpCommand(trimmed);
+    }
+
+    /**
      * Parses user input into command for execution.
      *
      * @param userInput full user input string
@@ -75,8 +92,7 @@ public class AddressBookParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
-
+            return parseHelp(arguments);
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/homey/ui/HelpWindow.java
+++ b/src/main/java/homey/ui/HelpWindow.java
@@ -1,8 +1,10 @@
 package homey.ui;
 
+import java.util.Map;
 import java.util.logging.Logger;
 
 import homey.commons.core.LogsCenter;
+import homey.commons.util.BrowserUtil;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -15,11 +17,27 @@ import javafx.stage.Stage;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2526s1-cs2103t-f15a-4.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
+
+    /**
+     * Maps help topics (command words) to their User Guide anchor IDs.
+     * Keys are what the user types (e.g. "add", "edit"), and values are the
+     * fragment parts of the UG URL (e.g. "#adding-a-person-add").
+     * Update this if UG headings change (copy the link icon next to a heading
+     * in the UG and use the part after the '#').
+     */
+    private static final Map<String, String> ANCHORS = Map.of(
+            "add", "#adding-a-person-add",
+            "edit", "#editing-a-person-edit",
+            "delete", "#deleting-a-person-delete",
+            "find", "#locating-persons-by-name-find",
+            "list", "#listing-all-persons-list",
+            "help", "#viewing-help-help"
+    );
 
     @FXML
     private Button copyButton;
@@ -87,6 +105,33 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void focus() {
         getRoot().requestFocus();
+    }
+
+    /**
+     * Opens the User Guide in the system's default web browser.
+     * If the browser cannot be opened, shows this help window instead
+     * so the user can view and copy the URL manually.
+     */
+    public void openInBrowserOrShow() {
+        boolean opened = BrowserUtil.open(USERGUIDE_URL);
+        if (!opened) {
+            show();
+        }
+    }
+
+    /**
+     * Opens the User Guide at a specific section if a topic is given.
+     * Falls back to showing this help window (with the link) if the browser can't be opened.
+     *
+     * @param topic Command/topic to open (e.g. "add", "edit"). If null or unknown, opens the UG root.
+     */
+    public void openInBrowserOrShow(String topic) {
+        String anchor = (topic == null) ? "" : ANCHORS.getOrDefault(topic, "");
+        String url = USERGUIDE_URL + anchor;
+        boolean opened = BrowserUtil.open(url);
+        if (!opened) {
+            show();
+        }
     }
 
     /**

--- a/src/main/java/homey/ui/MainWindow.java
+++ b/src/main/java/homey/ui/MainWindow.java
@@ -136,15 +136,12 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Opens the help window or focuses on it if it's already opened.
+     * Opens the User Guide in the default web browser when Help is clicked or F1 is pressed.
+     * If the browser cannot be opened, shows the help window instead.
      */
     @FXML
     public void handleHelp() {
-        if (!helpWindow.isShowing()) {
-            helpWindow.show();
-        } else {
-            helpWindow.focus();
-        }
+        helpWindow.openInBrowserOrShow();
     }
 
     void show() {
@@ -179,7 +176,9 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             if (commandResult.isShowHelp()) {
-                handleHelp();
+                commandResult.getHelpTopic().ifPresentOrElse(
+                        t -> helpWindow.openInBrowserOrShow(t), () -> helpWindow.openInBrowserOrShow()
+                );
             }
 
             if (commandResult.isExit()) {


### PR DESCRIPTION
Change help button to open UserGuide (UG) directly on browser instead of having to copy UG URL, opening browser, then pasting it inside for user convenience.
Also add optional topic to HelpCommand (e.g. `help add`) to allow user to directly search for specific help for a particular command. Maintains window with URL if browswer cannot be opened.