### PR TITLE
Update Help Command topics and fix unsupported topics

### DIFF
--- a/src/main/java/homey/logic/parser/AddressBookParser.java
+++ b/src/main/java/homey/logic/parser/AddressBookParser.java
@@ -36,23 +36,6 @@ public class AddressBookParser {
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
     /**
-     * Parses the help command with an optional topic.
-     * Examples:
-     * - "help" -> new HelpCommand()
-     * - "help add" -> new HelpCommand("add")
-     *
-     * @param arguments The raw arguments after the "help" keyword.
-     * @return a HelpCommand with or without a topic.
-     */
-    private Command parseHelp(String arguments) {
-        String trimmed = arguments.trim();
-        if (trimmed.isEmpty()) {
-            return new HelpCommand();
-        }
-        return new HelpCommand(trimmed);
-    }
-
-    /**
      * Parses the 'list' family of commands (e.g., "list", "list archive").
      * Normalises whitespace/nulls before delegating to {@link ListCommandParser}.
      */
@@ -109,7 +92,7 @@ public class AddressBookParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return parseHelp(arguments);
+            return new HelpCommandParser().parse(arguments);
 
         case TransactionStageCommand.COMMAND_WORD:
             return new TransactionStageCommandParser().parse(arguments);

--- a/src/main/java/homey/logic/parser/HelpCommandParser.java
+++ b/src/main/java/homey/logic/parser/HelpCommandParser.java
@@ -1,0 +1,57 @@
+package homey.logic.parser;
+
+import java.util.Locale;
+import java.util.Set;
+
+import homey.logic.commands.HelpCommand;
+import homey.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments for the {@code HelpCommand}.
+ * Supports an optional topic (e.g. {@code help add}) and validates it against
+ * a predefined set of supported topics.
+ * If no topic is provided, a default {@code HelpCommand} is returned.
+ * If an unsupported topic is given, a {@link ParseException} is thrown.
+ * Examples:
+ * help opens User Guide home
+ * help add opens "add" section
+ * help list meeting opens "list meeting" section
+ * help 123 throws ParseException
+ */
+public final class HelpCommandParser implements Parser<HelpCommand> {
+
+    // Whitelist topics actually support
+    private static final Set<String> ALLOWED = Set.of(
+            "add", "edit", "delete", "find", "find a/", "find t/", "find r/", "find s/", "relation", "list",
+            "list meeting", "clear", "transaction", "help", "remark", "archive", "unarchive", "exit", "meeting"
+    );
+
+    /** Trim, lowercase, and collapse internal whitespace to a single space. */
+    private static String normalize(String s) {
+        return s == null ? "" : s.trim()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", " ");
+    }
+
+    @Override
+    public HelpCommand parse(String args) throws ParseException {
+        String trimmed = args.trim();
+        if (trimmed.isEmpty()) {
+            return new HelpCommand();
+        }
+
+        if (trimmed.equalsIgnoreCase("offline")) {
+            // for offline to be implemented later
+            return new HelpCommand("offline");
+        }
+
+        String topic = normalize(trimmed);
+        if (!ALLOWED.contains(topic)) {
+            throw new ParseException(
+                    "Unknown help topic: '" + trimmed + "'. Allowed: " + String.join(", ", ALLOWED)
+                            + "\n\n" + HelpCommand.MESSAGE_USAGE
+            );
+        }
+        return new HelpCommand(topic);
+    }
+}

--- a/src/main/java/homey/ui/HelpWindow.java
+++ b/src/main/java/homey/ui/HelpWindow.java
@@ -42,11 +42,14 @@ public class HelpWindow extends UiPart<Stage> {
             Map.entry("exit", "#exiting-the-program-exit"),
             Map.entry("find a/", "#locating-persons-by-address-find-a"),
             Map.entry("find t/", "#locating-persons-by-tag-find-t"),
+            Map.entry("find r/", "#locating-persons-by-relation-find-r"),
+            Map.entry("find s/", "#locating-persons-by-transaction-stage-find-s"),
             Map.entry("relation", "#add-relational-tag-relation"),
             Map.entry("transaction", "#changing-the-transaction-stage"),
             Map.entry("archive", "#archiving-persons-archive"),
             Map.entry("unarchive", "#unarchiving-persons-unarchive"),
             Map.entry("remark", "#adding-a-remark-remark"),
+            Map.entry("meeting", "#adding-a-meeting-when-creating-a-contact-add"),
             Map.entry("list meeting", "#listing-contacts-by-meeting-date-list-meeting")
     );
 

--- a/src/test/java/homey/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/homey/logic/parser/AddressBookParserTest.java
@@ -94,8 +94,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
     }
+
 
     @Test
     public void parseCommand_list() throws Exception {

--- a/src/test/java/homey/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/homey/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,82 @@
+package homey.logic.parser;
+
+import static homey.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import homey.logic.commands.HelpCommand;
+import homey.logic.parser.exceptions.ParseException;
+
+public class HelpCommandParserTest {
+
+    private HelpCommandParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = new HelpCommandParser();
+    }
+
+    @Test
+    public void parse_empty_success() throws Exception {
+        HelpCommand cmd = parser.parse("");
+        assertTrue(cmd instanceof HelpCommand);
+        assertTrue(cmd.getTopic().isEmpty(), "Empty args should yield no topic");
+    }
+
+    @Test
+    public void parse_validSingleWordTopics_success() throws Exception {
+        HelpCommand cmdAdd = parser.parse("add");
+        assertEquals(Optional.of("add"), cmdAdd.getTopic());
+
+        HelpCommand cmdEdit = parser.parse("edit");
+        assertEquals(Optional.of("edit"), cmdEdit.getTopic());
+
+        HelpCommand cmdExit = parser.parse("exit");
+        assertEquals(Optional.of("exit"), cmdExit.getTopic());
+    }
+
+    @Test
+    public void parse_validMultiWordAndPrefixes_success() throws Exception {
+        HelpCommand cmdListMeeting = parser.parse("list meeting");
+        assertEquals(Optional.of("list meeting"), cmdListMeeting.getTopic());
+
+        HelpCommand cmdFindAddr = parser.parse("find a/");
+        assertEquals(Optional.of("find a/"), cmdFindAddr.getTopic());
+
+        HelpCommand cmdFindTag = parser.parse("find t/");
+        assertEquals(Optional.of("find t/"), cmdFindTag.getTopic());
+
+        // New ones you added:
+        HelpCommand cmdFindRel = parser.parse("find r/");
+        assertEquals(Optional.of("find r/"), cmdFindRel.getTopic());
+
+        HelpCommand cmdFindStage = parser.parse("find s/");
+        assertEquals(Optional.of("find s/"), cmdFindStage.getTopic());
+    }
+
+    @Test
+    public void parse_normalizesWhitespaceAndCase_success() throws Exception {
+        HelpCommand cmd = parser.parse("   LiSt    MEeTing   ");
+        // parser lowercases and collapses internal whitespace
+        assertEquals(Optional.of("list meeting"), cmd.getTopic());
+    }
+
+    @Test
+    public void parse_invalidNumeric_throws() {
+        assertThrows(ParseException.class, () -> parser.parse("3"));
+        assertThrows(ParseException.class, () -> parser.parse("  12345  "));
+    }
+
+    @Test
+    public void parse_invalidUnknownTopic_throws() {
+        assertThrows(ParseException.class, () -> parser.parse("random"));
+        assertThrows(ParseException.class, () -> parser.parse("find tag"));
+        assertThrows(ParseException.class, () -> parser.parse("a/"));
+        assertThrows(ParseException.class, () -> parser.parse("add person"));
+    }
+}


### PR DESCRIPTION
Fix Help command accepting unsupported topics, and also include existing topics `add m/`, `find s/` and `find r/`. Also abstract out helpParser() method from AddressBookParser to HelpCommandParser.