### PR TITLE
Fix editing remark bug

### DIFF
--- a/src/main/java/homey/logic/commands/EditCommand.java
+++ b/src/main/java/homey/logic/commands/EditCommand.java
@@ -102,7 +102,7 @@ public class EditCommand extends Command {
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+    static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());

--- a/src/main/java/homey/logic/commands/RemarkCommand.java
+++ b/src/main/java/homey/logic/commands/RemarkCommand.java
@@ -54,14 +54,11 @@ public class RemarkCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(
-                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), personToEdit.getRelation(), personToEdit.getStage(), remark,
-                personToEdit.getTags());
-
+        EditCommand.EditPersonDescriptor descriptor = new EditCommand.EditPersonDescriptor();
+        descriptor.setRemark(remark);
+        Person editedPerson = EditCommand.createEditedPerson(personToEdit, descriptor);
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
 


### PR DESCRIPTION
This PR modifies the RemarkCommand to correctly update a person’s remark by reusing logic from EditCommand rather than manually reconstructing the Person object. Previously, RemarkCommand manually created a new Person using its constructor, which increased coupling and required manual updates whenever new fields were added to Person.
This caused maintenance issues and potential data loss if future fields were not copied over correctly.